### PR TITLE
hello_world.py - single quotation marks bugfix

### DIFF
--- a/custom_components/hello_world.py
+++ b/custom_components/hello_world.py
@@ -12,7 +12,7 @@ hello_world:
 """
 
 # The domain of your component. Should be equal to the name of your component.
-DOMAIN = "hello_world"
+DOMAIN = 'hello_world'
 
 
 def setup(hass, config):


### PR DESCRIPTION
Component not found unless using single quotation marks around the DOMAIN name rather than double.
Is this intentional or an issue with HA?