### PR TITLE
Fix expose_service_async example domain

### DIFF
--- a/custom_components/expose_service_async/__init__.py
+++ b/custom_components/expose_service_async/__init__.py
@@ -5,7 +5,7 @@ import logging
 from homeassistant.core import callback
 
 # The domain of your component. Should be equal to the name of your component.
-DOMAIN = "expose_service_sync"
+DOMAIN = "expose_service_async"
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
The `DOMAIN` was previously set as "expose_service_sync" for this example