### PR TITLE
Update detailed_hello_world_push example

### DIFF
--- a/custom_components/detailed_hello_world_push/__init__.py
+++ b/custom_components/detailed_hello_world_push/__init__.py
@@ -1,11 +1,8 @@
 """The Detailed Hello World Push integration."""
 from __future__ import annotations
 
-import asyncio
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
 
 from . import hub
 from .const import DOMAIN
@@ -15,29 +12,15 @@ from .const import DOMAIN
 PLATFORMS: list[str] = ["cover", "sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Hello World component."""
-    # Ensure our name space for storing objects is a known type. A dict is
-    # common/preferred as it allows a separate instance of your class for each
-    # instance that has been created in the UI.
-    hass.data.setdefault(DOMAIN, {})
-
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Hello World from a config entry."""
     # Store an instance of the "connecting" class that does the work of speaking
     # with your actual devices.
-    hass.data[DOMAIN][entry.entry_id] = hub.Hub(hass, entry.data["host"])
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub.Hub(hass, entry.data["host"])
 
     # This creates each HA object for each platform your device requires.
     # It's done by calling the `async_setup_entry` function in each platform module.
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
-
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
 
 
@@ -46,15 +29,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # This is called when an entry/configured device is to be removed. The class
     # needs to unload itself, and remove callbacks. See the classes for further
     # details
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(
-                    entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/custom_components/detailed_hello_world_push/cover.py
+++ b/custom_components/detailed_hello_world_push/cover.py
@@ -5,9 +5,13 @@ from typing import Any
 
 # These constants are relevant to the type of entity we are using.
 # See below for how they are used.
-from homeassistant.components.cover import (ATTR_POSITION, SUPPORT_CLOSE,
-                                            SUPPORT_OPEN, SUPPORT_SET_POSITION,
-                                            CoverEntity)
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    CoverEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,23 +24,15 @@ from .const import DOMAIN
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback
+    async_add_devices: AddEntitiesCallback,
 ) -> None:
     """Add cover for passed config_entry in HA."""
     # The hub is loaded from the associated hass.data entry that was created in the
     # __init__.async_setup_entry function
     hub = hass.data[DOMAIN][config_entry.entry_id]
 
-    # The next few lines find all of the entities that will need to be added
-    # to HA. Note these are all added to a list, so async_add_devices can be
-    # called just once.
-    new_devices = []
-    for roller in hub.rollers:
-        roller_entity = HelloWorldCover(roller)
-        new_devices.append(roller_entity)
-    # If we have any new devices, add them
-    if new_devices:
-        async_add_devices(new_devices)
+    # Add all entities to HA
+    async_add_devices([HelloWorldCover(roller) for roller in hub.rollers])
 
 
 # This entire class could be written to extend a base class to ensure common attributes
@@ -58,6 +54,18 @@ class HelloWorldCover(CoverEntity):
         # Usual setup is done here. Callbacks are added in async_added_to_hass.
         self._roller = roller
 
+        # A unique_id for this entity with in this domain. This means for example if you
+        # have a sensor on this cover, you must ensure the value returned is unique,
+        # which is done here by appending "_cover". For more information, see:
+        # https://developers.home-assistant.io/docs/entity_registry_index/#unique-id-requirements
+        # Note: This is NOT used to generate the user visible Entity ID used in automations.
+        self._attr_unique_id = f"{self._roller.roller_id}_cover"
+
+        # This is the name for this *entity*, the "name" attribute from "device_info"
+        # is used as the device name for device screens in the UI. This name is used on
+        # entity screens, and used to build the Entity ID that's used is automations etc.
+        self._attr_name = self._roller.name
+
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
         # Importantly for a push integration, the module that will be getting updates
@@ -72,16 +80,6 @@ class HelloWorldCover(CoverEntity):
         """Entity being removed from hass."""
         # The opposite of async_added_to_hass. Remove any registered call backs here.
         self._roller.remove_callback(self.async_write_ha_state)
-
-    # A unique_id for this entity with in this domain. This means for example if you
-    # have a sensor on this cover, you must ensure the value returned is unique,
-    # which is done here by appending "_cover". For more information, see:
-    # https://developers.home-assistant.io/docs/entity_registry_index/#unique-id-requirements
-    # Note: This is NOT used to generate the user visible Entity ID used in automations.
-    @property
-    def unique_id(self) -> str:
-        """Return Unique ID string."""
-        return f"{self._roller.roller_id}_cover"
 
     # Information about the devices that is partially visible in the UI.
     # The most critical thing here is to give this entity a name so it is displayed
@@ -114,14 +112,6 @@ class HelloWorldCover(CoverEntity):
             "manufacturer": self._roller.hub.manufacturer,
         }
 
-    # This is the name for this *entity*, the "name" attribute from "device_info"
-    # is used as the device name for device screens in the UI. This name is used on
-    # entity screens, and used to build the Entity ID that's used is automations etc.
-    @property
-    def name(self) -> str:
-        """Return the name of the roller."""
-        return self._roller.name
-
     # This property is important to let HA know if this entity is online or not.
     # If an entity is offline (return False), the UI will refelect this.
     @property
@@ -129,7 +119,7 @@ class HelloWorldCover(CoverEntity):
         """Return True if roller and hub is available."""
         return self._roller.online and self._roller.hub.online
 
-    # The follwing properties are how HA knows the current state of the device.
+    # The following properties are how HA knows the current state of the device.
     # These must return a value from memory, not make a live query to the device/hub
     # etc when called (hence they are properties). For a push based integration,
     # HA is notified of changes via the async_write_ha_state call. See the __init__

--- a/custom_components/detailed_hello_world_push/cover.py
+++ b/custom_components/detailed_hello_world_push/cover.py
@@ -24,7 +24,7 @@ from .const import DOMAIN
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_devices: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add cover for passed config_entry in HA."""
     # The hub is loaded from the associated hass.data entry that was created in the
@@ -32,7 +32,7 @@ async def async_setup_entry(
     hub = hass.data[DOMAIN][config_entry.entry_id]
 
     # Add all entities to HA
-    async_add_devices([HelloWorldCover(roller) for roller in hub.rollers])
+    async_add_entities(HelloWorldCover(roller) for roller in hub.rollers)
 
 
 # This entire class could be written to extend a base class to ensure common attributes

--- a/custom_components/detailed_hello_world_push/hub.py
+++ b/custom_components/detailed_hello_world_push/hub.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 import random
 
+from homeassistant.core import HomeAssistant
+
 
 class Hub:
     """Dummy hub for Hello World example."""
@@ -56,7 +58,7 @@ class Roller:
         self.moving = 0
 
         # Some static information about this device
-        self.firmware_version = "0.0.{}".format(random.randint(1, 9))
+        self.firmware_version = f"0.0.{random.randint(1, 9)}"
         self.model = "Test Device"
 
     @property

--- a/custom_components/detailed_hello_world_push/sensor.py
+++ b/custom_components/detailed_hello_world_push/sensor.py
@@ -100,21 +100,6 @@ class BatterySensor(SensorBase):
 
         self._state = random.randint(0, 100)
 
-    # This property can return additional metadata about this device. Here it's
-    # returning the voltage of the battery. The actual percentage is returned in
-    # the state property below. These values are displayed in the entity details
-    # screen at the bottom below the history graph.
-    # A number of defined attributes are available, see the homeassistant.const module
-    # for constants starting with ATTR_*.
-    # Again, if these values change, the async_write_ha_state method should be called.
-    # in this implementation, these values are assumed to be static.
-    # Note this functionality to display addition data on an entity appears to be
-    # exclusive to sensors. This information is not shown in the UI for a cover.
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the device."""
-        return {ATTR_VOLTAGE: self._roller.battery_voltage}
-
     # The value of this sensor. As this is a DEVICE_CLASS_BATTERY, this value must be
     # the battery level as a percentage (between 0 and 100)
     @property

--- a/custom_components/detailed_hello_world_push/sensor.py
+++ b/custom_components/detailed_hello_world_push/sensor.py
@@ -22,7 +22,7 @@ from .const import DOMAIN
 # Note how both entities for each roller sensor (battry and illuminance) are added at
 # the same time to the same list. This way only a single async_add_devices call is
 # required.
-async def async_setup_entry(hass, config_entry, async_add_devices):
+async def async_setup_entry(hass, config_entry, async_add_entities):
     """Add sensors for passed config_entry in HA."""
     hub = hass.data[DOMAIN][config_entry.entry_id]
 
@@ -31,7 +31,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         new_devices.append(BatterySensor(roller))
         new_devices.append(IlluminanceSensor(roller))
     if new_devices:
-        async_add_devices(new_devices)
+        async_add_entities(new_devices)
 
 
 # This base class shows the common properties and methods for a sensor as used in this

--- a/custom_components/detailed_hello_world_push/sensor.py
+++ b/custom_components/detailed_hello_world_push/sensor.py
@@ -8,14 +8,14 @@
 import random
 
 from homeassistant.const import (
+    ATTR_VOLTAGE,
     DEVICE_CLASS_BATTERY,
-    PERCENTAGE,
     DEVICE_CLASS_ILLUMINANCE,
+    PERCENTAGE,
 )
 from homeassistant.helpers.entity import Entity
-from .const import DOMAIN
 
-from homeassistant.const import ATTR_VOLTAGE
+from .const import DOMAIN
 
 
 # See cover.py for more details.
@@ -81,17 +81,24 @@ class BatterySensor(SensorBase):
     # https://developers.home-assistant.io/docs/core/entity/sensor
     device_class = DEVICE_CLASS_BATTERY
 
+    # The unit of measurement for this entity. As it's a DEVICE_CLASS_BATTERY, this
+    # should be PERCENTAGE. A number of units are supported by HA, for some
+    # examples, see:
+    # https://developers.home-assistant.io/docs/core/entity/sensor#available-device-classes
+    _attr_unit_of_measurement = PERCENTAGE
+
     def __init__(self, roller):
         """Initialize the sensor."""
         super().__init__(roller)
-        self._state = random.randint(0, 100)
 
-    # As per the sensor, this must be a unique value within this domain. This is done
-    # by using the device ID, and appending "_battery"
-    @property
-    def unique_id(self):
-        """Return Unique ID string."""
-        return f"{self._roller.roller_id}_battery"
+        # As per the sensor, this must be a unique value within this domain. This is done
+        # by using the device ID, and appending "_battery"
+        self._attr_unique_id = f"{self._roller.roller_id}_battery"
+
+        # The name of the entity
+        self._attr_name = f"{self._roller.name} Battery"
+
+        self._state = random.randint(0, 100)
 
     # This property can return additional metadata about this device. Here it's
     # returning the voltage of the battery. The actual percentage is returned in
@@ -106,9 +113,7 @@ class BatterySensor(SensorBase):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {}
-        attr[ATTR_VOLTAGE] = self._roller.battery_voltage
-        return attr
+        return {ATTR_VOLTAGE: self._roller.battery_voltage}
 
     # The value of this sensor. As this is a DEVICE_CLASS_BATTERY, this value must be
     # the battery level as a percentage (between 0 and 100)
@@ -117,21 +122,6 @@ class BatterySensor(SensorBase):
         """Return the state of the sensor."""
         return self._roller.battery_level
 
-    # The unit of measurement for this entity. As it's a DEVICE_CLASS_BATTERY, this
-    # should be PERCENTAGE. A number of units are supported by HA, for some
-    # examples, see:
-    # https://developers.home-assistant.io/docs/core/entity/sensor#available-device-classes
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return PERCENTAGE
-
-    # The same of this entity, as displayed in the entity UI.
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"{self._roller.name} Battery"
-
 
 # This is another sensor, but more simple compared to the battery above. See the
 # comments above for how each field works.
@@ -139,23 +129,19 @@ class IlluminanceSensor(SensorBase):
     """Representation of a Sensor."""
 
     device_class = DEVICE_CLASS_ILLUMINANCE
+    _attr_unit_of_measurement = "lx"
 
-    @property
-    def unique_id(self):
-        """Return Unique ID string."""
-        return f"{self._roller.roller_id}_illuminance"
+    def __init__(self, roller):
+        """Initialize the sensor."""
+        super().__init__(roller)
+        # As per the sensor, this must be a unique value within this domain. This is done
+        # by using the device ID, and appending "_battery"
+        self._attr_unique_id = f"{self._roller.roller_id}_illuminance"
 
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"{self._roller.name} Illuminance"
+        # The name of the entity
+        self._attr_name = f"{self._roller.name} Illuminance"
 
     @property
     def state(self):
         """Return the state of the sensor."""
         return self._roller.illuminance
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return "lx"


### PR DESCRIPTION
Updates the detailed_hello_world_push to reflect more the way how new integrations are supposed to look like (what I know from mainly review comments from Martin and others and the dev docs)

* Use helpers to set up the platforms
* Use helpers to unload the platforms
* Use instance attributes instead of properties where applicable
* Fixed a typo where `async_add_devices` was called but `async_add_entities` was defined
* Ran black and liniting.

