### PR TITLE
Fix iot_class in detailed_hello_world_push

### DIFF
--- a/custom_components/detailed_hello_world_push/manifest.json
+++ b/custom_components/detailed_hello_world_push/manifest.json
@@ -9,6 +9,6 @@
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@sillyfrog"],
-  "iot_class": "local_polling",
+  "iot_class": "local_push",
   "version": "0.1.0"
 }


### PR DESCRIPTION
Fix for [Wrong iot_class in detailed_hello_world_push](https://github.com/home-assistant/example-custom-config/issues/31#issuecomment-994749912).