### PR TITLE
Replace TEMP_CELSIUS with UnitOfTemperature.CELSIUS

### DIFF
--- a/custom_components/example_sensor/sensor.py
+++ b/custom_components/example_sensor/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -26,7 +26,7 @@ class ExampleSensor(SensorEntity):
     """Representation of a Sensor."""
 
     _attr_name = "Example Temperature"
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
 


### PR DESCRIPTION
TEMP_CELSIUS was deprecated
https://github.com/home-assistant/core/blob/dev/homeassistant/const.py#L580