### PR TITLE
Add cv.empty_config_schema

### DIFF
--- a/custom_components/hello_world/__init__.py
+++ b/custom_components/hello_world/__init__.py
@@ -13,10 +13,14 @@ hello_world:
 from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 # The domain of your component. Should be equal to the name of your component.
 DOMAIN = "hello_world"
+
+# Use empty_config_schema because the component does not have any config options
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:


### PR DESCRIPTION
The component does not have any config options, so using cv.empty_config_schema to ensure it passes validation.