### PR TITLE
Add cv.empty_config_schema

### DIFF
--- a/custom_components/expose_service_async/__init__.py
+++ b/custom_components/expose_service_async/__init__.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 import logging
 
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 # The domain of your component. Should be equal to the name of your component.
 DOMAIN = "expose_service_async"
 _LOGGER = logging.getLogger(__name__)
+
+# Use empty_config_schema because the component does not have any config options
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:


### PR DESCRIPTION
The component does not have any config options, so using cv.empty_config_schema to ensure it passes validation.